### PR TITLE
MOB Updates

### DIFF
--- a/example/config/config.exs
+++ b/example/config/config.exs
@@ -30,6 +30,6 @@ use Mix.Config
 #     import_config "#{Mix.env}.exs"
 
 config :shoehorn,
-  init: [],
+  init: [{IO, :puts, ["init_1"]},{IO, :puts, ["init_2"]}],
   app: :example,
-  handler: Example
+  handler: Example.ShoehornHandler

--- a/example/lib/example.ex
+++ b/example/lib/example.ex
@@ -1,9 +1,6 @@
 defmodule Example do
   def start(_, _) do
+    IO.puts "Example start"
     {:ok, self()}
-  end
-
-  def application_stopped(app) do
-    IO.puts "Application stopped: #{inspect app}"
   end
 end

--- a/example/lib/example/shoehorn_handler.ex
+++ b/example/lib/example/shoehorn_handler.ex
@@ -1,0 +1,29 @@
+defmodule Example.ShoehornHandler do
+  @behaviour Shoehorn.Handler
+
+  def init(_opts) do
+   {:ok, %{restart_counts: 0}}
+  end
+
+  def handle_application(:not_started, app, state) do
+    IO.puts "Application failed to start: #{inspect app} #{inspect state}"
+    {:halt, state}
+  end
+
+  def handle_application({:stopped, reason}, app, %{restart_counts: restart_counts} = state) when restart_counts < 2 do
+    IO.puts "Application stopped: #{inspect app} #{inspect state} #{inspect reason}"
+    Shoehorn.ApplicationController.ensure_all_started(app)
+    {:ok, %{state | restart_counts: restart_counts + 1}}
+  end
+
+  def handle_application({:stopped, reason}, app, %{restart_counts: restart_counts} = state) when restart_counts < 4 do
+    IO.puts "Application restart: #{inspect app} #{inspect state} #{inspect reason}"
+    Shoehorn.ApplicationController.ensure_all_started(app)
+    {:restart, %{state | restart_counts: restart_counts + 1}}
+  end
+
+  def handle_application({:stopped, reason}, app, state) do
+    IO.puts "Application stopped forever: #{inspect app} #{inspect state} #{inspect reason}"
+    {:halt, state}
+  end
+end

--- a/lib/shoehorn/handler.ex
+++ b/lib/shoehorn/handler.ex
@@ -1,13 +1,104 @@
 defmodule Shoehorn.Handler do
-  @callback application_stopped(app :: atom) :: any
+  @moduledoc """
+  A behaviour module for implementing handling of failing applications
 
-  defmacro __using__(_) do
-    quote do
-      @behaviour Shoehorn.Handler
-    end
+  A Shoehorn.Handler is a module that knows how to respond to specific
+  applications going down. There are two types of failing applications.
+  The first is an application that fails to initialize and the second
+  is an application that stops while it is running.
+
+  ## Example
+
+  The Shoehorn.Handler behaviour requires developers to implement two
+  callbacks. The `init` callback sets up any state the handler needs.
+  The `handle_application` callback processes the incoming failure and
+  replies with the action that the `Shoehorn.ApplicationController`
+  should take in case of application failure.
+
+          defmodule Example.ShoehornHandler do
+            @behaviour Shoehorn.Handler
+
+            def init(_opts) do
+              {:ok, %{restart_counts: 0}}
+            end
+
+            def handle_application(:not_started, _, state) do
+              {:halt, state}
+            end
+
+            def handle_application({:stopped, reason}, :non_esential_app, state) do
+              {:continue, state}
+            end
+
+            def handle_application({:stopped, reason}, :esential_app, %{restart_counts: restart_counts} = state) when restart_counts < 2 do
+              {:restart, %{state | restart_counts: restart_counts + 1}}
+            end
+
+            def handle_application({:stopped, reason}, _, state) do
+              {:halt, state}
+            end
+          end
+
+  We initailize our `Shoehorn.Handler` with a restart count for state
+  by calling `init` with the configuration options from our shoehorn
+  config. This state is stored and passed in from the
+  `Shoehorn.ApplicationController`.
+
+  The next step is to implement our handlers. When called with
+  `:not_started` an application failed in `init` and never started
+  running. In our case we are going to inform the controller that
+  the system should completely shutdown and there is no saving.
+
+  When we have an app that is non-esential we return `:contiue` to
+  inform the system to keep going like nothing happened.
+
+  We restart the esential application of our system two times, and
+  then we tell the system to halt if restarting wasn't fixing the
+  system.
+  """
+
+  @typedoc """
+  The action letting `Shoehorn.ApplicationController` know what to do
+
+  * `:contine` - keep the system going like nothing happened
+  * `:restart` - restart the application
+  * `:halt`    - stop the application and bring the system down
+  """
+  @type action :: :continue | :restart | :halt
+
+  @typedoc """
+  The cause that is firing the handler
+
+  * `:not_started` - the application failed during init
+  * `{:stopped, reason}` - the application has stopped with the reason given
+  """
+  @type cause :: :not_started | {:stopped, any}
+
+  @doc """
+  Callback to intialize the handle
+
+  The callback must return a tuple of `{:ok, state}`. The state can be
+  anything and will be passed back to `handle_application` any time it
+  is called. If anything other than `:ok` is returned the system will
+  halt.
+  """
+  @callback init(opts :: map) :: {:ok, state :: any}
+
+  @doc """
+  Callback for handling application crashes
+
+  Called with the cause, application name, and the handlers current
+  state. It must return a tuple containg the `action` that the
+  `Shoehorn.ApplicationController` should take, and the new state
+  of the handler.
+  """
+  @callback handle_application(cause, app :: atom, state :: any ) :: {action, state :: any}
+
+  def init(_opts) do
+    {:ok, :no_state}
   end
 
-  def application_stopped(_app) do
-    :ok
+  def handle_application(_reason, _app, state) do
+    {:halt, state}
   end
 end


### PR DESCRIPTION
These are the updates from the MOB programing session on Friday with @mobileoverlord @ConnorRigby @adkron 

The goal is to add control points so that the handler can do 1 of 3 things:
1. Let the VM shutdown (default)
1. Tell Shoehorn to ignore the error as the handler will restart the app at a later point
1. Tell Shoehorn to restart.  This is useful if an error occurs in an "init" app that can be recovered from (i.e. Ecto)

 