### PR TITLE
Adds examples to documentation

### DIFF
--- a/lib/shoehorn/handler.ex
+++ b/lib/shoehorn/handler.ex
@@ -18,7 +18,7 @@ defmodule Shoehorn.Handler do
   starts up.
 
   The `application_exited` callback processes the incoming failure and
-  replies with the action that `Shoehorn` should take in case of
+  replies with the reaction that `Shoehorn` should take in case of
   application failure.
 
           defmodule Example.ShoehornHandler do
@@ -38,6 +38,7 @@ defmodule Shoehorn.Handler do
             end
 
             def application_exited(:essential_app, _reason, %{restart_counts: restart_counts} = state) when restart_counts < 2 do
+              # repair actions to make before restarting
               Application.ensure_all_started(:essential_app)
               {:continue, %{state | restart_counts: restart_counts + 1}}
             end
@@ -49,27 +50,27 @@ defmodule Shoehorn.Handler do
 
   We initialize our `Shoehorn.Handler` with a restart count for state
   by calling `init` with the configuration options from our shoehorn
-  config. This state is stored and passed in from the
+  config. The stored state is passed in from the
   `Shoehorn.ApplicationController`.
 
-  When we have an application start up we will put a message in the
+  When we have an application startup, we will put a message on the
   console to notify the developer.
 
-  When we have an non-essential application fail we return `:continue` to
+  When we have a non-essential application fail we return `:continue` to
   inform the system to keep going like nothing happened.
 
   We restart the essential application of our system two times, and
-  then we tell the system to halt if restarting wasn't fixing the
+  then we tell the system to halt if starting over wasn't fixing the
   system.
   """
 
   @typedoc """
-  The action letting `Shoehorn.ApplicationController` know what to do
+  The reaction letting `Shoehorn.ApplicationController` know what to do
 
   * `:continue` - keep the system going like nothing happened
   * `:halt`    - stop the application and bring the system down
   """
-  @type action :: :continue | :halt
+  @type reaction :: :continue | :halt
 
   @typedoc """
   The cause that is firing the handler
@@ -77,40 +78,58 @@ defmodule Shoehorn.Handler do
   @type cause :: any
 
   @doc """
-  Callback to intialize the handle
+  Callback to initialize the handle
 
-  The callback must return a tuple of `{:ok, state}`. The state can be
-  anything and will be passed back to `handle_application` any time it
-  is called. If anything other than `:ok` is returned the system will
-  halt.
+  The callback must return a tuple of `{:ok, state}`. Where state is
+  the initial state of the handler. The system will halt if the
+  return is anything other than `:ok`.
   """
   @callback init(opts :: map) :: {:ok, state :: any}
 
   @doc """
   Callback for handling application crashes
 
-  Called with the application name, cause, and the handlers current
-  state. It must return a tuple containg the `action` that the
+  Called with the application name, cause, and the handler's
+  state. It must return a tuple contaning the `reaction` that the
   `Shoehorn.ApplicationController` should take, and the new state
   of the handler.
 
-  The default implementation returns unchanged state, and a `:halt`
-  action.
+  The code that you execute here can be used to notify or capture some
+  information before halting the system. This information can later
+  be used to recreate the issue or debug the problem  causing the
+  application to exit.
+
+  Use `application_exited` as a place for a last-ditch effort to fix the
+  issue and restart the application.  Ideally, capture
+  some information on the system state, and solve it upstream. Shoehorn
+  restarts should be used as a splint to keep a critical system
+  running.
+
+  The default implementation returns the previous state, and a `:halt`
+  reaction.
   """
-  @callback application_exited(cause, app :: atom, state :: any) :: {action, state :: any}
+  @callback application_exited(cause, app :: atom, state :: any) :: {reaction, state :: any}
 
   @doc """
   Callback for handling application starts
 
-  Called with the application name, and the handlers current
-  state. It must return a tuple containg the `action` that the
+  Called with the application name, and the handler's
+  state. It must return a tuple containing the `reaction` that the
   `Shoehorn.ApplicationController` should take, and the new state
   of the handler.
 
+            def application_exited(:essential_app, _reason, state) do
+              # repair actions to make before restarting
+              # notify someone of the crash and the details
+              # log debug data
+              Application.ensure_all_started(:essential_app)
+              {:continue, %{state | restart_counts: restart_counts + 1}}
+            end
+
   The default implementation returns unchanged state, and a `:continue`
-  action.
+  reaction.
   """
-  @callback application_started(app :: atom, state :: any) :: {action, state :: any}
+  @callback application_started(app :: atom, state :: any) :: {reaction, state :: any}
 
   defmacro __using__(_opts) do
     quote do
@@ -144,29 +163,29 @@ defmodule Shoehorn.Handler do
     %__MODULE__{module: module, state: state}
   end
 
-  @spec invoke(:application_exited, app :: atom, cause, t) :: {action, t}
+  @spec invoke(:application_exited, app :: atom, cause, t) :: {reaction, t}
   def invoke(
         :application_exited = event,
         app,
         cause,
         %__MODULE__{state: state, module: module} = handler
       ) do
-    {action, new_state} = apply(module, event, [app, cause, state])
-    {action, %{handler | state: new_state}}
+    {reaction, new_state} = apply(module, event, [app, cause, state])
+    {reaction, %{handler | state: new_state}}
   rescue
     e ->
       IO.puts("Shoehorn handler raised an exception: #{inspect(e)}")
       {:halt, state}
   end
 
-  @spec invoke(:application_started, app :: atom, t) :: {action, t}
+  @spec invoke(:application_started, app :: atom, t) :: {reaction, t}
   def invoke(
         :application_started = event,
         app,
         %__MODULE__{state: state, module: module} = handler
       ) do
-    {action, new_state} = apply(module, event, [app, state])
-    {action, %{handler | state: new_state}}
+    {reaction, new_state} = apply(module, event, [app, state])
+    {reaction, %{handler | state: new_state}}
   rescue
     e ->
       IO.puts("Shoehorn handler raised an exception: #{inspect(e)}")


### PR DESCRIPTION
The examples didn't have any hint at what could happen in the callbacks.
I added a few comments that point to possible actions that might be
taken. I also suggest that the upstream is the proper place to fix this.

A few other English/spelling errors are also fixed.

Amos King @adkron <amos@binarynoggin.com>