### PR TITLE
Enforce that the application config declares a handler.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,29 +2,6 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure for your application as:
-#
-#     config :shoehorn, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:shoehorn, :key)
-#
-# Or configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+config :shoehorn,
+  app: :shoehorn,
+  handler: Shoehorn.Handler.Ignore

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,7 @@ defmodule Shoehorn.Mixfile do
   end
 
   def application do
+    enforce_handler()
     [extra_applications: [:crypto], mod: {Shoehorn, []}]
   end
 
@@ -53,5 +54,31 @@ defmodule Shoehorn.Mixfile do
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/nerves-project/shoehorn"}
     ]
+  end
+
+  def enforce_handler() do
+    unless Application.get_env(:shoehorn, :handler) do
+      Mix.raise("""
+      The default strategy for how Shoehorn handles OTP application exits has changed.
+      Before this release, if an application were to exit, the node would remain running
+      and that applications would remain stopped. This may be desirable for development
+      and test but is typically undesirable in production. This behavior can be
+      customized by configuring the `handler` in the config. For example, in dev you can
+      use the module `Shoehorn.Handler.Ignore` to prevent the node from halting on failure. 
+
+        # config/dev.exs
+
+        config :shoehorn,
+          handler: Shoehorn.Handler.Ignore
+
+      In prod, you can specify the default handler, or implement your own.
+
+        # config/dev.exs
+
+        config :shoehorn,
+          handler: Shoehorn.Handler.Default
+          
+      """)
+    end
   end
 end

--- a/test/fixtures/fail_init/config/config.exs
+++ b/test/fixtures/fail_init/config/config.exs
@@ -1,3 +1,5 @@
 use Mix.Config
 
-config :shoehorn, app: :fail_init
+config :shoehorn,
+  app: :fail_init,
+  handler: Shoehorn.Handler.Ignore

--- a/test/fixtures/no_handler/.gitignore
+++ b/test/fixtures/no_handler/.gitignore
@@ -1,0 +1,21 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+mix.lock

--- a/test/fixtures/no_handler/config/config.exs
+++ b/test/fixtures/no_handler/config/config.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :shoehorn,
+  app: :no_handler

--- a/test/fixtures/no_handler/lib/no_handler.ex
+++ b/test/fixtures/no_handler/lib/no_handler.ex
@@ -1,0 +1,2 @@
+defmodule NoHandler do
+end

--- a/test/fixtures/no_handler/mix.exs
+++ b/test/fixtures/no_handler/mix.exs
@@ -1,0 +1,35 @@
+defmodule NoHandler.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :no_handler,
+      version: "0.1.0",
+      elixir: "~> 1.4",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Configuration for the OTP application
+  #
+  # Type "mix help compile.app" for more information
+  def application do
+    # Specify extra applications you'll use from Erlang/Elixir
+    [extra_applications: []]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:my_dep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options
+  defp deps do
+    [{:shoehorn, path: "../../../."}]
+  end
+end

--- a/test/fixtures/pre_init/config/config.exs
+++ b/test/fixtures/pre_init/config/config.exs
@@ -2,29 +2,6 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure for your application as:
-#
-#     config :pre_init, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:pre_init, :key)
-#
-# Or configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+config :shoehorn,
+  app: :pre_init,
+  handler: Shoehorn.Handler.Ignore

--- a/test/fixtures/simple_app/config/config.exs
+++ b/test/fixtures/simple_app/config/config.exs
@@ -1,3 +1,5 @@
 use Mix.Config
 
-config :shoehorn, app: :simple_app
+config :shoehorn,
+  app: :simple_app,
+  handler: Shoehorn.Handler.Ignore

--- a/test/shoehorn_test.exs
+++ b/test/shoehorn_test.exs
@@ -7,6 +7,7 @@ defmodule ShoehornTest do
   import MixTestHelper
 
   @simple_app_path Path.join([File.cwd!(), "test", "fixtures", "simple_app"])
+  @no_handler_app_path Path.join([File.cwd!(), "test", "fixtures", "no_handler"])
 
   defmacrop with_simple_app(body) do
     quote do
@@ -101,5 +102,13 @@ defmodule ShoehornTest do
 
       System.cmd(app_path, ["stop"])
     end
+  end
+
+  test "Config missing handler will raise" do
+    old_dir = File.cwd!()
+    File.cd!(@no_handler_app_path)
+    mix("deps.get")
+    assert {:error, 1, _} = mix("compile")
+    File.cd!(old_dir)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
-Application.put_env(:shoehorn, :handler, ShoehornTest.Handler)
+Mix.shell(Mix.Shell.Process)
 
 ExUnit.start()


### PR DESCRIPTION
This will enforce that people go through a project update strategy and prevent dev / test brick states.