### PR TITLE
Update the runtime: false specs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,9 +26,9 @@ defmodule Shoehorn.Mixfile do
 
   defp deps do
     [
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
-      {:distillery, "~> 2.0", runtime: false},
-      {:ex_doc, "~> 0.18", only: :dev}
+      {:distillery, "~> 2.0"},
+      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:ex_doc, "~> 0.18", only: [:dev, :test], runtime: false}
     ]
   end
 


### PR DESCRIPTION
* Distillery has runtime parts, so remove runtime: false
* ex_doc and dialyxir are runtime: false and only dev and prod