### PR TITLE
Readme and example change

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ mix release
 Go to the release directory and boot your app using `shoehorn`
 
 ```sh
-_build/dev/rel/simple_app/bin/simple_app console_boot shoehorn
+_build/dev/rel/simple_app/bin/simple_app console_boot $(pwd)/_build/dev/rel/simple_app/bin/shoehorn
 ```
 
 From here we can see that the shoehorn was started, but `simple_app` was not.

--- a/example/mix.exs
+++ b/example/mix.exs
@@ -15,7 +15,7 @@ defmodule Example.MixProject do
   def application do
     [
       mod: {Example, []},
-      extra_applications: [:logger]
+      extra_applications: [:distillery, :logger]
     ]
   end
 


### PR DESCRIPTION
Simple change to the README.md example for starting a compiled release to use the absolute path to shoehorn.boot script.

Also adds `:distillery` to extra_applications of `example` app to fix starting it locally after latest distillery release

Elixir 1.8.2 OTP 22

Based on this warning when `mix release`
```elixir
jonjon@ 📂 {example} $ _mix release
==> Assembling release..
==> Building release example:0.1.0 using environment dev
One or more direct or transitive dependencies are missing from
    :applications or :included_applications, they will not be included
    in the release:

        :distillery

    This can cause your application to fail at runtime. If you are sure
    that this is not an issue, you may ignore this warning.

==> Generated Shoehorn Boot Script
    Run using shoehorn:
      Interactive: _build/dev/rel/example/bin/example console_boot _build/dev/rel/example/bin/shoehorn
```

And this error when trying to run _without_ using absolute path or excluding `:distillery` from extra applications:
```sh
jonjon@ 📂 {example} $ _build/dev/rel/example/bin/example console_boot _build/dev/rel/example/bin/shoehorn
{"init terminating in do_boot",{undef,[{'Elixir.Mix.Releases.Config.Provider',init,[[]],[]},{init,eval_script,2,[]},{init,do_boot,3,[]}]}}
init terminating in do_boot ({undef,[{Elixir.Mix.Releases.Config.Provider,init,[[_]],[]},{init,eval_script,2,[]},{init,do_boot,3,[]}]})

Crash dump is being written to: erl_crash.dump...done
Unable to configure release!
```

