### PR TITLE
Minor fixes

### DIFF
--- a/lib/shoehorn.ex
+++ b/lib/shoehorn.ex
@@ -134,12 +134,13 @@ defmodule Shoehorn do
 
       _ ->
         %Release{profile: %{output_dir: output_dir}, name: app} = app_release
-        relative_output_dir = Path.relative_to_cwd(output_dir)
+        absolute_output_dir = Path.relative_to_cwd(output_dir)
+                              |> Path.absname()
 
         Shell.info("""
         Generated Shoehorn Boot Script
             Run using shoehorn:
-              Interactive: #{relative_output_dir}/bin/#{app} console_boot #{relative_output_dir}/bin/shoehorn
+              Interactive: #{absolute_output_dir}/bin/#{app} console_boot #{absolute_output_dir}/bin/shoehorn
         """)
     end
 

--- a/lib/shoehorn/handler.ex
+++ b/lib/shoehorn/handler.ex
@@ -107,7 +107,7 @@ defmodule Shoehorn.Handler do
   The default implementation returns the previous state, and a `:halt`
   reaction.
   """
-  @callback application_exited(cause, app :: atom, state :: any) :: {reaction, state :: any}
+  @callback application_exited(app :: atom, cause, state :: any) :: {reaction, state :: any}
 
   @doc """
   Callback for handling application starts


### PR DESCRIPTION
* The `Shoehorn.Handler.application_exited/3` callback definition had args backwards to how things were actually working, so I switched those.
* Running shoehorn in interactive requires using the absolute path to the shoehorn script. So this adjusts the shell output after compiling the script to show the absolute path when instructing how to run interactive