### PR TITLE
Update app list example and usage to show arguments as a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ from error. In the example above, we initialize the runtime, bring up the networ
 and ensure we can receive new firmware updates. If `my_app` were to fail to start,
 the node would still be in a state where it can receive new firmware over the network.
 
-You can also specify an `{m, f, [a]}` in the init list for performing
-simple initialization time tasks.
+You can also specify an `{m, f, a}` in the init list for performing
+simple initialization time tasks. Shoehorn will call [Kernel.apply/3](https://hexdocs.pm/elixir/Kernel.html#apply/3) for each `{m, f, a}` formatted entry.
 
 ```elixir
 # config/config.exs

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ from error. In the example above, we initialize the runtime, bring up the networ
 and ensure we can receive new firmware updates. If `my_app` were to fail to start,
 the node would still be in a state where it can receive new firmware over the network.
 
-You can also specify an `{m, f, a}` in the init list for performing
+You can also specify an `{m, f, [a]}` in the init list for performing
 simple initialization time tasks.
 
 ```elixir
@@ -80,7 +80,7 @@ simple initialization time tasks.
 
 config :shoehorn,
   app: :my_app,
-  init: [{IO, :puts, "Init"}, :nerves_runtime]
+  init: [{IO, :puts, ["Init"]}, :nerves_runtime]
 ```
 
 ## Application Failures
@@ -153,3 +153,4 @@ the list of default applications to include. If you depend on these applications
 at runtime, you can add `:distillery` to the `extra_applications` list and or
 `:mix` to the `included_applications` list in the `application/0` callback in
 your `mix.exs` file.
+


### PR DESCRIPTION
It appears that `{m, f, a}` now requires `a` to be a list. I believe this comes down to `application_controller.ex:42`

If you would rather support `a` not as a list I can add another clause of `start_app/1` instead