### PR TITLE
Fix URL for the contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,4 +3,4 @@
 Please refer to the [Nerves Project Contributing Guide], which applies to all
 `nerves-project` repositories.
 
-[Nerves Project Contributing Guide]: https://github.com/nerves-project/nerves/blob/main/CONTRIBUTING.md
+[Nerves Project Contributing Guide]: https://github.com/nerves-project/nerves/blob/main/.github/CONTRIBUTING.md


### PR DESCRIPTION
The URL was missing a folder in the path, and was producing a 404. 
Old URL: https://github.com/nerves-project/nerves/blob/main/CONTRIBUTING.md
New URL: https://github.com/nerves-project/nerves/blob/main/.github/CONTRIBUTING.md