### PR TITLE
Remove macro in favor of behaviour for Shoehorn.Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,15 @@ the application.
 
 ```elixir
 defmodule Example.RestartHandler do
-  use Shoehorn.Handler
+  @behavior Shoehorn.Handler
+
+  def init(_opts) do
+    {:ok, nil}
+  end
+
+  def application_started(_app, state) do
+    {:continue, state}
+  end
 
   def application_exited(app, _reason, state) do
     Logger.error("Application stopped: #{inspect(app)} #{inspect(state)}")

--- a/lib/shoehorn/handler.ex
+++ b/lib/shoehorn/handler.ex
@@ -21,7 +21,7 @@ defmodule Shoehorn.Handler do
   with the reaction that `Shoehorn` should take in case of application failure.
 
           defmodule Example.ShoehornHandler do
-            use Shoehorn.Handler
+            @behaviour Shoehorn.Handler
 
             @impl Shoehorn.Handler
             def init(_opts) do
@@ -142,26 +142,6 @@ defmodule Shoehorn.Handler do
   reaction.
   """
   @callback application_started(app :: atom, state :: any) :: {reaction, state :: any}
-
-  defmacro __using__(_opts) do
-    quote do
-      @behaviour Shoehorn.Handler
-
-      def init(_opts) do
-        {:ok, :no_state}
-      end
-
-      def application_started(_app, state) do
-        {:continue, state}
-      end
-
-      def application_exited(_app, _reason, state) do
-        {:halt, state}
-      end
-
-      defoverridable init: 1, application_started: 2, application_exited: 3
-    end
-  end
 
   @type t :: %__MODULE__{module: atom, state: any}
   @type opts :: [handler: atom]

--- a/lib/shoehorn/handler/ignore.ex
+++ b/lib/shoehorn/handler/ignore.ex
@@ -2,7 +2,7 @@ defmodule Shoehorn.Handler.Ignore do
   @moduledoc """
   Default handler that ignores all events
   """
-  use Shoehorn.Handler
+  @behaviour Shoehorn.Handler
 
   @impl Shoehorn.Handler
   def init(_opts) do

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -129,7 +129,7 @@ end
 
 defmodule ShoehornTest.Handler do
   @moduledoc false
-  use Shoehorn.Handler
+  @behaviour Shoehorn.Handler
 
   @impl Shoehorn.Handler
   def init(_opts) do


### PR DESCRIPTION
This is a breaking change that requires users to replace references to
`use Shoehorn.Handler` with `@behaviour Shoehorn.Handler` and implement
any missing callbacks.

The reason for this change is catch callback mistakes at compile-time.
Previously, the automatically provided functions could be used and cause
errors to not be handled.
