### PR TITLE
Move error handler registration to application callback

### DIFF
--- a/lib/shoehorn/application.ex
+++ b/lib/shoehorn/application.ex
@@ -17,6 +17,8 @@ defmodule Shoehorn.Application do
         if String.ends_with?(bootfile, "shoehorn") do
           opts = Application.get_all_env(:shoehorn)
 
+          :error_logger.add_report_handler(Shoehorn.Handler.Proxy, opts)
+
           [{Shoehorn.ApplicationController, opts}]
         else
           []

--- a/lib/shoehorn/application_controller.ex
+++ b/lib/shoehorn/application_controller.ex
@@ -8,8 +8,6 @@ defmodule Shoehorn.ApplicationController do
 
   @impl GenServer
   def init(opts) do
-    :error_logger.add_report_handler(Shoehorn.Handler.Proxy, opts)
-
     app = app(opts[:app])
 
     init = opts[:init] || []


### PR DESCRIPTION
This only needs to be called once and this seems a simpler, more obvious
place to put it.
