### PR TITLE
Rename handler modules to simpler names

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ events by registering with the erlang kernel
 
 Application start and exit events will attempt to execute a callback to the
 configured `Shoehorn.Handler` module. By default, the module
-`Shoehorn.Handler.Ignore` will be called. This module is configured to continue
+`Shoehorn.DefaultHandler` will be called. This module is configured to continue
 the Erlang VM if any OTP application were to exit, for any reason. In
 production, you may want to customize the action on failure so you can gather
 forensics or perform updates to the node.  You can do this by overriding the

--- a/lib/shoehorn/application.ex
+++ b/lib/shoehorn/application.ex
@@ -17,7 +17,7 @@ defmodule Shoehorn.Application do
         if String.ends_with?(bootfile, "shoehorn") do
           opts = Application.get_all_env(:shoehorn)
 
-          :error_logger.add_report_handler(Shoehorn.Handler.Proxy, opts)
+          :error_logger.add_report_handler(Shoehorn.ReportHandler, opts)
 
           [{Shoehorn.ApplicationController, opts}]
         else

--- a/lib/shoehorn/default_handler.ex
+++ b/lib/shoehorn/default_handler.ex
@@ -1,4 +1,4 @@
-defmodule Shoehorn.Handler.Ignore do
+defmodule Shoehorn.DefaultHandler do
   @moduledoc """
   Default handler that ignores all events
   """

--- a/lib/shoehorn/handler.ex
+++ b/lib/shoehorn/handler.ex
@@ -150,7 +150,7 @@ defmodule Shoehorn.Handler do
 
   @spec init(opts) :: t | no_return
   def init(opts) do
-    module = opts[:handler] || Shoehorn.Handler.Ignore
+    module = opts[:handler] || Shoehorn.DefaultHandler
     {:ok, state} = module.init(opts)
     %__MODULE__{module: module, state: state}
   end

--- a/lib/shoehorn/report_handler.ex
+++ b/lib/shoehorn/report_handler.ex
@@ -1,4 +1,4 @@
-defmodule Shoehorn.Handler.Proxy do
+defmodule Shoehorn.ReportHandler do
   @moduledoc false
 
   @behaviour :gen_event


### PR DESCRIPTION
This renames Proxy to ReportHandler to better match that it handles
error reports. It's an internal module, so this isn't expected to be
breaking.

This also renames the Ignore handler to DefaultHandler since it's the
default. This may be breaking if a project manually specifies to use it.
