### PR TITLE
Remove support for running MFA's on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,12 @@ the network, and ensure that we can receive new firmware updates. Now, if
 `my_app` fails to start, the node would still be in a state where it can receive
 new firmware over the network.
 
-You can also specify an `{m, f, a}` in the `init` list for performing simple
-initialization time tasks. Shoehorn will call
-[Kernel.apply/3](https://hexdocs.pm/elixir/Kernel.html#apply/3) for each `{m, f,
-a}`-formatted entry.
-
 ```elixir
 # config/config.exs
 
 config :shoehorn,
   app: :my_app,
-  init: [{IO, :puts, ["Init"]}, :nerves_runtime]
+  init: [:nerves_runtime]
 ```
 
 ## Application Failures

--- a/lib/shoehorn/application_controller.ex
+++ b/lib/shoehorn/application_controller.ex
@@ -40,16 +40,9 @@ defmodule Shoehorn.ApplicationController do
     {:noreply, s}
   end
 
-  defp start_app({m, f, a}) when is_list(a) do
-    apply(m, f, a)
-  end
-
-  defp start_app({m, a}) when is_list(a) do
-    apply(m, :start_link, a)
-  end
-
   defp start_app(app) when is_atom(app) do
-    Application.ensure_all_started(app)
+    _ = Application.ensure_all_started(app)
+    :ok
   end
 
   defp start_app(init_call) do
@@ -57,8 +50,6 @@ defmodule Shoehorn.ApplicationController do
     Shoehorn encountered an error while trying to call #{inspect(init_call)}
     during initialization. The argument needs to be formatted as
 
-    {Module, :function, [args]}
-    {Module, [args]}
     :application
     """)
 


### PR DESCRIPTION
As part of the change to load applications via boot scripts, support for
running MFA's needs to be removed. The fix is to move the code called by
the MFA into an Application.start callback.

In addition to MFA's not being supported via the boot script, there was
a subtle issue with them that could be confusing: It looks like the MFA
will be called before the applications listed after it have been
started. This isn't guaranteed to be true. Normally, it works since the
`:init` list usually only has a few items and they're not
interdependent. However, when it doesn't hold true, it's confusing since
it really looks like it should.

In hindsight, the use of MFA's looks like it has turned into a
convenience for avoiding the creation of yet another OTP application to
do something simple like report status or start Erlang distribution. It
feels like there are other, more robust ways of accomplishing this..
