### PR TITLE
Replace error_logger handler with logger handler

### DIFF
--- a/lib/shoehorn/application.ex
+++ b/lib/shoehorn/application.ex
@@ -7,7 +7,7 @@ defmodule Shoehorn.Application do
   def start(_type, _args) do
     if using_shoehorn?() do
       opts = Application.get_all_env(:shoehorn)
-      :error_logger.add_report_handler(Shoehorn.ReportHandler, opts)
+      :logger.add_handler(:shoehorn, Shoehorn.ReportHandler, %{config: opts})
     end
 
     opts = [strategy: :one_for_one, name: Shoehorn.Supervisor]


### PR DESCRIPTION
This is a first naive port based on the docs here: https://www.erlang.org/doc/apps/kernel/logger_chapter.html#example--implement-a-handler

I've opted for doing the pattern matching in the process generating the logs, so there's less message passing involved. I expect that to be fast enough to not slow down the `application_controller`.

I've not yet run tests with it, as I currently get this error on the `ShoehornTest` case:

```
Protocol 'inet_tcp': the name simple_app@Lillith seems to be in use by another Erlang node
--rpc-eval : RPC failed with reason :nodedown
…
```

Closes #79 