### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Shoehorn
 
 [![Hex version](https://img.shields.io/hexpm/v/shoehorn.svg "Hex version")](https://hex.pm/packages/shoehorn)
-[![API docs](https://img.shields.io/hexpm/v/shoehorn.svg?label=hexdocs "API docs")](https://hexdocs.pm/shoehorn/Shoehorn.html)
+[![API docs](https://img.shields.io/hexpm/v/shoehorn.svg?label=hexdocs "API docs")](https://shoehorn.hexdocs.pm/Shoehorn.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/shoehorn/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/shoehorn/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/shoehorn)](https://api.reuse.software/info/github.com/nerves-project/shoehorn)
 
@@ -132,7 +132,7 @@ _mode_ specified when the application started. The modes are:
   applications are terminated (the default behaviour).
 
 Unless overridden in the Mix release using the [`:applications`
-option](https://hexdocs.pm/mix/Mix.Tasks.Release.html#module-options), Shoehorn
+option](https://mix.hexdocs.pm/Mix.Tasks.Release.html#module-options), Shoehorn
 most applications as `:temporary` and monitors application events by registering
 with the Erlang [error_logger](http://erlang.org/doc/man/error_logger.html).
 

--- a/example/crash_app/README.md
+++ b/example/crash_app/README.md
@@ -17,5 +17,5 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/crash_app>.
+be found at <https://crash-app.hexdocs.pm>.
 

--- a/example/crash_app/lib/crash_app/application.ex
+++ b/example/crash_app/lib/crash_app/application.ex
@@ -1,5 +1,5 @@
 defmodule CrashApp.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -14,7 +14,7 @@ defmodule CrashApp.Application do
       # {CrashApp.Worker, arg}
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: CrashApp.Supervisor]
     Supervisor.start_link(children, opts)

--- a/example/load_only_app/lib/load_only_app/application.ex
+++ b/example/load_only_app/lib/load_only_app/application.ex
@@ -1,5 +1,5 @@
 defmodule LoadOnlyApp.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -16,7 +16,7 @@ defmodule LoadOnlyApp.Application do
       # {LoadOnlyApp.Worker, arg}
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: LoadOnlyApp.Supervisor]
     Supervisor.start_link(children, opts)

--- a/example/my_project/lib/my_project/application.ex
+++ b/example/my_project/lib/my_project/application.ex
@@ -1,5 +1,5 @@
 defmodule MyProject.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -12,7 +12,7 @@ defmodule MyProject.Application do
       # {MyProject.Worker, arg}
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: MyProject.Supervisor]
     Supervisor.start_link(children, opts)

--- a/example/optional_app/README.md
+++ b/example/optional_app/README.md
@@ -17,5 +17,5 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/optional_app>.
+be found at <https://optional-app.hexdocs.pm>.
 

--- a/example/optional_app/lib/optional_app/application.ex
+++ b/example/optional_app/lib/optional_app/application.ex
@@ -1,5 +1,5 @@
 defmodule OptionalApp.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -12,7 +12,7 @@ defmodule OptionalApp.Application do
       # {OptionalApp.Worker, arg}
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: OptionalApp.Supervisor]
     Supervisor.start_link(children, opts)

--- a/example/some_app/README.md
+++ b/example/some_app/README.md
@@ -17,5 +17,5 @@ end
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/some_app>.
+be found at <https://some-app.hexdocs.pm>.
 

--- a/example/some_app/lib/some_app/application.ex
+++ b/example/some_app/lib/some_app/application.ex
@@ -1,5 +1,5 @@
 defmodule SomeApp.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -12,7 +12,7 @@ defmodule SomeApp.Application do
       # {SomeApp.Worker, arg}
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: SomeApp.Supervisor]
     Supervisor.start_link(children, opts)

--- a/example/system_init/lib/system_init/application.ex
+++ b/example/system_init/lib/system_init/application.ex
@@ -1,5 +1,5 @@
 defmodule SystemInit.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -16,7 +16,7 @@ defmodule SystemInit.Application do
       # {SystemInit.Worker, arg}
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: SystemInit.Supervisor]
     Supervisor.start_link(children, opts)


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://shoehorn.hexdocs.pm/Shoehorn.html): Status 404
❌ Verification failed for https://crash-app.hexdocs.pm>: %Req.TransportError{reason: :nxdomain}
❌ Verification failed for https://optional-app.hexdocs.pm>: %Req.TransportError{reason: :nxdomain}
❌ Verification failed for https://some-app.hexdocs.pm>: %Req.TransportError{reason: :nxdomain}
⚠️ Verification finished: 3 success, 4 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>